### PR TITLE
Optimize "calculateTrueAnomaly"

### DIFF
--- a/SoA/OrbitComponentUpdater.cpp
+++ b/SoA/OrbitComponentUpdater.cpp
@@ -75,12 +75,9 @@ f64 OrbitComponentUpdater::calculateTrueAnomaly(f64 meanAnomaly, f64 e) {
     f64 E; ///< Eccentric Anomaly
     f64 F;
     E = meanAnomaly;
-    F = E - e * sin(meanAnomaly) - meanAnomaly;
     for (int n = 0; n < ITERATIONS; n++) {
-        E = E -
-            F / (1.0 - e * cos(E));
-        F = E -
-            e * sin(E) - meanAnomaly;
+        F = E - e * sin(E) - meanAnomaly;
+        E -= F / (1.0 - e * cos(E));
     }
     // 3. Calculate true anomaly
     return atan2(sqrt(1.0 - e * e) * sin(E), cos(E) - e);


### PR DESCRIPTION
Previously, `F` was calculated one more time than it needed to be, since it was calculated before the loop started and at the end of the loop where it's needed. So I got rid of the formula outside the loop and moved the one inside to the top. The formulas are actually the same because of `E = meanAnomaly`.